### PR TITLE
Update template.tpl

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -581,7 +581,7 @@ ___WEB_PERMISSIONS___
             "listItem": [
               {
                 "type": 1,
-                "string": "https://cookie-cdn.1trust.app/*"
+                "string": "https://cdn.cookielaw.org/"
               }
             ]
           }


### PR DESCRIPTION
it seems https://cookie-cdn.1trust.app/* was used as injection url before I assume since it was in this code, but now the injection url must be https://cdn.cookielaw.org/
be aware that no wildcard is needed at the end, at least for tag manager templates because if the page path is just / then it is already seen wildcard after that
tested and working with the mentioned change. not working without it currently